### PR TITLE
使用onebot适配器中的MessageSegment替换原有的CQ码消息

### DIFF
--- a/nonebot_plugin_eventmonitor/__init__.py
+++ b/nonebot_plugin_eventmonitor/__init__.py
@@ -9,7 +9,8 @@ from nonebot.adapters.onebot.v11 import (
     GroupDecreaseNoticeEvent,
     GroupIncreaseNoticeEvent,
     GroupAdminNoticeEvent,
-    LuckyKingNotifyEvent
+    LuckyKingNotifyEvent,
+    MessageSegment
 )
 
 from .stamp import chuo_send_msg
@@ -88,10 +89,14 @@ async def send_rongyu(event: HonorNotifyEvent, bot: Bot):
 
 @files.handle()                                                                         #上传群文件
 async def handle_first_receive(event: GroupUploadNoticeEvent):
-    rely = f'[CQ:at,qq={event.user_id}]\n' \
-           f'[CQ:image,file=https://q4.qlogo.cn/headimg_dl?dst_uin={event.user_id}&spec=640]' \
-           f'\n 上传了新文件，感谢你一直为群里做贡献喵~[CQ:face,id=175]'
-    await files.finish(message=Message(rely))
+    # rely = f'[CQ:at,qq={event.user_id}]\n' \
+    #        f'[CQ:image,file=https://q4.qlogo.cn/headimg_dl?dst_uin={event.user_id}&spec=640]' \
+    #        f'\n 上传了新文件，感谢你一直为群里做贡献喵~[CQ:face,id=175]'
+    # await files.finish(message=Message(rely))
+    rely = MessageSegment.at(event.user_id) + '\n' + \
+           MessageSegment.image(f'https://q4.qlogo.cn/headimg_dl?dst_uin={event.user_id}&spec=640') + \
+           '\n 上传了新文件，感谢你一直为群里做贡献喵~' + MessageSegment.face(175)
+    await files.finish(message=rely)
 
 
 @del_user.handle()                                                                      #退群事件
@@ -115,5 +120,7 @@ async def admin_chance(event: GroupAdminNoticeEvent, bot: Bot):
 
 @red_packet.handle()                                                                    #红包运气王
 async def hongbao(event: LuckyKingNotifyEvent):
-    rely_msg = f"[CQ:at,qq={event.user_id}]\n本次红包运气王为：[CQ:at,qq={event.target_id}]"
-    await red_packet.finish(message=Message(rely_msg))
+    # rely_msg = f"[CQ:at,qq={event.user_id}]\n本次红包运气王为：[CQ:at,qq={event.target_id}]"
+    # await red_packet.finish(message=Message(rely_msg))
+    rely_msg = MessageSegment.at(event.user_id) + "\n" + "本次红包运气王为：" + MessageSegment.at(event.target_id)
+    await red_packet.finish(message=rely_msg)


### PR DESCRIPTION
作者您好！我在阅读您的源代码时发现您在发送消息时使用的是CQ码，由于onebotV11中已经集成了MessageSegment对象可用于发送诸如at、image等多媒体消息，所以您可以使用MessageSegment来替代原有的CQ码消息，已经在本次PR中对源码做了一些小修改（主要是__init__.py中的几个处理器函数），辛苦您于百忙之中抽空查看一下！